### PR TITLE
Meta: Drop compatibility with unsupported php version

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,7 @@
         }
     ],
     "require": {
-        "php": "^5.6 || ^7.0",
+        "php": ">=7.3",
         "ext-mbstring": "*",
         "ext-gd": "*",
         "tecnickcom/tcpdf": "^6.2"


### PR DESCRIPTION
Require php 7.3 or newer, this mainly for compatibity with phpunit version 9.